### PR TITLE
Fix an edge case with certain FreeCAD projects

### DIFF
--- a/freecad2any
+++ b/freecad2any
@@ -93,8 +93,20 @@ def preg_match(rex, s, m, opts={}):
     return False
 
 
-def list_methods(obj):
-    return [method_name for method_name in dir(obj) if callable(getattr(obj, method_name))]
+def list_methods(object, spacing=20):
+    methodList = []
+    for method_name in dir(object):
+        try:
+            if callable(getattr(object, method_name)):
+                methodList.append(str(method_name))
+        except Exception:
+            methodList.append(str(method_name))
+        processFunc = (lambda s: ' '.join(s.split())) or (lambda s: s)
+        for method in methodList:
+            try:
+                print(str(method.ljust(spacing)) + ' ' + processFunc(str(getattr(object, method).__doc__)[0:90]))
+            except Exception:
+                print(method.ljust(spacing) + ' ' + ' getattr() failed')
 
 
 def export(fn, fno, fmt):

--- a/freecad2any
+++ b/freecad2any
@@ -149,7 +149,7 @@ def export(fn, fno, fmt):
 
     for o in App.ActiveDocument.Objects:
         # find root object and export the shape
-        if len(o.InList) == 0:
+        if hasattr(o, "Shape") and len(o.InList) == 0:
             print("INF: => exporting (%s) %s" % (fmt, fno))
             # print(list_methods(o))
             if fmt == "step":

--- a/freecad2any
+++ b/freecad2any
@@ -60,8 +60,7 @@ if not os.path.exists("/usr/lib/freecad"):  # -- we are installed not ordinary, 
                 except Exception as e:
                     sys.exit("EXCEPTION: failed to execute under modified environment, " + e)
             else:
-                print("ERR: didn't find FreeCAD installation locally or as snap, abort.")
-                # sys.exit(-1)
+                print("INF: didn't find FreeCAD installation locally or as snap.")
 
 FREECADPATH = ""
 


### PR DESCRIPTION
On FreeCAD projects with other 3D objects (e.g. VRML) embedded, e.g. as a reference to build a case around, the script could crash.

This resolves the crash by ensuring we have a Shape to export before trying,